### PR TITLE
update fix for ida 7.0

### DIFF
--- a/ifl.py
+++ b/ifl.py
@@ -810,10 +810,15 @@ class FunctionsListForm_t(PluginForm):
         self.addr_view.resizeColumnToContents(6)
         self.addr_view.resizeColumnToContents(7)
 #public
-    @pyqtSlot()
-    def longoperationcomplete(self):
-        data = g_DataManager.currentRva
-        self.setRefOffset(data)
+    try:
+        #@pyqtSlot()
+        def longoperationcomplete(self):
+            data = g_DataManager.currentRva
+            self.setRefOffset(data)
+    except TypeError:
+        def longoperationcomplete(self):
+            data = g_DataManager.currentRva
+            self.setRefOffset(data)
                 
     def setRefOffset(self, data):
         if not data:


### PR DESCRIPTION
for ida 7.0 fix
the signal imit don't gets through when calling #@pyqtSlot() here is a small fix to avoid the signal error.
```
Traceback (most recent call last):
  File "/plugins/ifl.py", line 900, in OnCreate
    g_DataManager.updateSignal.connect(self.longoperationcomplete)
TypeError: connect() failed between DataManager.updateSignal[] and longoperationcomplete()```