### PR TITLE
Fix possible function typo in function_at

### DIFF
--- a/ifl.py
+++ b/ifl.py
@@ -42,7 +42,7 @@ def va_to_rva(va):
 def function_at(ea):
     start = ea
     functions = Functions(start)
-    for func in Functions():
+    for func in functions:
         return func
     return None
 


### PR DESCRIPTION
It seems that there might be an unintended typo in `function_at`

Because the iteration is done on a new generator (`Functions()`) instead of the initialized one (`functions`) it will always return the address of the first function:

```
Python>function_at(0x00000001800257D1)
0x180001060
Python>function_at(0x000000018002C950)
0x180001060
Python>function_at(0x000000018002A8D0)
0x180001060
```

I tried to fix it by making minimal changes but it can also be written nicely as
```python
def function_at(ea):
    return next(Functions(ea), None)
```