### PR TITLE
Fix typo: refered → referred in Qt tab label

### DIFF
--- a/ifl.py
+++ b/ifl.py
@@ -1362,7 +1362,7 @@ class FunctionsListForm_t(PluginForm):
 
         # Create a Tab widget for references:
         self.refs_tabs = QtWidgets.QTabWidget()
-        self.refs_tabs.insertTab(0, self.refs_view, "Is refered by")
+        self.refs_tabs.insertTab(0, self.refs_view, "Is referred by")
         self.refs_tabs.insertTab(1, self.refsfrom_view, "Refers to")
 
         # Create filter


### PR DESCRIPTION
Fixes a typo in the Qt tab label (line 1365 of ifl.py): ''Is refered by'' → ''Is referred by''. This is a user-facing label in the References tab.